### PR TITLE
fix: 커뮤니티 게시글 페이지 내 연결된 서비스 표시 불가 버그 제거

### DIFF
--- a/apps/client/app/community/post/[postId]/page.tsx
+++ b/apps/client/app/community/post/[postId]/page.tsx
@@ -465,7 +465,7 @@ export default function CommunityPost(props: DefaultProps) {
                     href={`/join-party/plan/${
                       partySelectedPlanInfos[service.serviceId - 1]
                         .planDetailInfos[
-                        partySelectedPlanInfos[service.serviceId]
+                        partySelectedPlanInfos[service.serviceId - 1]
                           .planDetailInfos.length - 1
                       ].id
                     }`}


### PR DESCRIPTION
resolve #13 

## Description

기존 커뮤니티 게시글 페이지 내에서 연결된 서비스를 표시하는 로직에 문제가
발견되어 해당 버그를 제거하였습니다.