### PR TITLE
feat: 커뮤니티 게시글 페이지 내 댓글 미존재 시 표시 UI 추가

### DIFF
--- a/apps/client/app/community/post/[postId]/components/comment/EmptyCommentListItem.tsx
+++ b/apps/client/app/community/post/[postId]/components/comment/EmptyCommentListItem.tsx
@@ -1,5 +1,32 @@
-import React from 'react';
+import React from "react";
 
 export default function EmptyCommentListItem() {
-  return <div>EmptyCommentListItem</div>;
+  return (
+    <div
+      className="flex flex-col items-center text-xs text-[#88909a] mb-10"
+      style={{ alignContent: "center" }}
+    >
+      <svg
+        width="88"
+        height="88"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="scale-90"
+      >
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M36 15c-13 0-24 11-24 24s11 24 24 24h2v9h1l10-9h3c13 0 24-11 24-24S65 15 52 15H36z"
+          fill="#d1d2d3"
+        />
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M47 39c0 2-1 3-3 3s-3-1-3-3 1-3 3-3 3 1 3 3zm-13 0c0 2-1 3-3 3s-3-1-3-3 1-3 3-3 3 1 3 3zm23 3c2 0 3-1 3-3s-1-3-3-3-3 1-3 3 1 3 3 3z"
+          fill="#f9fafb"
+        />
+      </svg>
+      <span className="text-inherit">가장 먼저 댓글을 남겨보세요!</span>
+    </div>
+  );
 }


### PR DESCRIPTION
resolve #15 

## Description

기존 커뮤니티 게시글 페이지 내에서 댓글이 존재하지 않을 시
단순히 텍스트로만 댓글이 존재함을 않음을 표시하였는데, 이를
명확히 표현하도록 관련 UI를 추가하였습니다.

- 추가된 커뮤니티 게시글 페이지 내 댓글 미존재 시 표시되는 UI 화면

<img width="702" alt="Screenshot 2024-09-11 at 10 59 36 AM" src="https://github.com/user-attachments/assets/7abea2d6-dd0c-448a-a4f4-e71cd30d880e">