### PR TITLE
feat: 커뮤니티 게시글 삭제 API 연동

### DIFF
--- a/apps/client/app/community/post/[postId]/components/ConfirmDeleteCommunityPostModal.tsx
+++ b/apps/client/app/community/post/[postId]/components/ConfirmDeleteCommunityPostModal.tsx
@@ -1,16 +1,18 @@
-'use client';
+"use client";
 
-import { Modal } from 'flowbite-react';
-import AOS from 'aos';
-import 'aos/dist/aos.css';
-import React, { useEffect, useState } from 'react';
-import axiosInstance from '@/utils/axiosInstance';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
-import Image from 'next/image';
-import uncheckedImg from '@/public/images/unchecked.png';
-import checkedImg from '@/public/images/checked.png';
-import { useRouter } from 'next/navigation';
+import { Modal } from "flowbite-react";
+import AOS from "aos";
+import "aos/dist/aos.css";
+import React, { useEffect, useState } from "react";
+import axiosInstance from "@/utils/axiosInstance";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { useRouter } from "next/navigation";
+
+// 커뮤니티 게시글 삭제 API
+const deleteCommunityPost = (postId: string) => {
+  return axiosInstance.delete(`/private/community/${postId}`);
+};
 
 interface ConfirmDeleteCommunityPostModalProps {
   openConfirmDeleteCommunityPostModal: string | undefined;
@@ -20,45 +22,47 @@ interface ConfirmDeleteCommunityPostModalProps {
   postId: string;
 }
 
-// 커뮤니티 게시글 삭제하기 API
-const disbandParty = (partyId: string) => {
-  return axiosInstance.delete(`/private/party/${partyId}`);
-};
-
 export default function ConfirmDeleteCommunityPostModal({
   openConfirmDeleteCommunityPostModal,
   setOpenConfirmDeleteCommunityPostModal,
   postId,
 }: ConfirmDeleteCommunityPostModalProps) {
-  const router = useRouter();
-
-  const disbandPartyMutation = useMutation({
-    mutationFn: disbandParty,
+  const deleteCommunityPostMutation = useMutation({
+    mutationFn: deleteCommunityPost,
     onMutate: () => {},
     onError: (error: AxiosError) => {
       const resData: any = error.response;
-      switch (resData?.status) {
-        case 409:
-          switch (resData?.data.error.status) {
-            // case 'CONFLICT':
-            //   alert('이미 처리된 결제 정보입니다.');
-            //   router.push('/my-page');
-            //   break;
-            default:
-              alert('정의되지 않은 http code입니다.');
-          }
-          break;
-        default:
-          alert('정의되지 않은 http status code입니다');
+
+      console.log(resData);
+      switch (
+        resData?.status
+        // case 409:
+        //   switch (resData?.data.error.status) {
+        //     default:
+        //       alert("정의되지 않은 http code입니다.");
+        //   }
+        //   break;
+        // default:
+        //   alert("정의되지 않은 http status code입니다");
+      ) {
       }
     },
     onSuccess: (data) => {
-      alert('파티가 해산되었습니다.');
-      setOpenConfirmDeleteCommunityPostModal(undefined);
-      router.push('/my-party');
+      const httpStatusCode = data.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          alert("게시글이 삭제됐어요");
+          router.push("/community");
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
     },
     onSettled: () => {},
   });
+
+  const router = useRouter();
 
   const [isCheckedPartyLeaderGuide, setIsCheckedPartyLeaderGuide] =
     useState(false);
@@ -69,34 +73,33 @@ export default function ConfirmDeleteCommunityPostModal({
 
   return (
     <Modal
-      size='sm'
-      show={openConfirmDeleteCommunityPostModal === 'default'}
-      data-aos='fade-zoom'
-      data-aos-duration='300'
+      size="sm"
+      show={openConfirmDeleteCommunityPostModal === "default"}
+      data-aos="fade-zoom"
+      data-aos-duration="300"
     >
-      <Modal.Body className='flex flex-col gap-y-3 pb-0 spacing-y-28'>
-        <p className='text-lg font-bold'>게시글을 삭제하시겠습니까?</p>
+      <Modal.Body className="flex flex-col gap-y-3 pb-0 spacing-y-28">
+        <p className="text-lg font-bold">게시글을 삭제하시겠습니까?</p>
 
-        <p className='h-[1.25rem] text-sm text-[#727272] font-medium'>
+        <p className="h-[1.25rem] text-sm text-[#727272] font-medium">
           삭제 후 내용을 되돌릴 수 없습니다.
         </p>
       </Modal.Body>
-      <Modal.Footer className='border-none'>
+      <Modal.Footer className="border-none">
         <button
           onClick={() => {
             setOpenConfirmDeleteCommunityPostModal(undefined);
           }}
-          className='w-full text-[#787878] text-[0.8rem] bg-[#efefef] hover:brightness-[96%] duration-150 ease-out p-[0.825rem] rounded-[0.45rem] font-bold'
+          className="w-full text-[#787878] text-[0.8rem] bg-[#efefef] hover:brightness-[96%] duration-150 ease-out p-[0.825rem] rounded-[0.45rem] font-bold"
         >
           뒤로가기
         </button>
         <button
           onClick={() => {
+            deleteCommunityPostMutation.mutate(postId);
             setOpenConfirmDeleteCommunityPostModal(undefined);
-            alert('게시글이 삭제되었습니다.');
-            router.push('/community');
           }}
-          className='w-full text-white text-[0.8rem] bg-[#3a8af9] hover:bg-[#1c6cdb] duration-150 ease-out p-[0.825rem] rounded-[0.45rem] font-bold'
+          className="w-full text-white text-[0.8rem] bg-[#3a8af9] hover:bg-[#1c6cdb] duration-150 ease-out p-[0.825rem] rounded-[0.45rem] font-bold"
         >
           삭제하기
         </button>


### PR DESCRIPTION
resolve #16 

## Description

서버 측 `커뮤니티 게시글을 삭제` API를 커뮤니티 게시글 페이지에서
작성자 본인만 해당 API를 호출할 수 있도록 하는 기능을 추가하였습니다.