### PR TITLE
feat: 커뮤니티 게시글 댓글 추가 API 연동

### DIFF
--- a/apps/client/app/community/post/[postId]/components/comment/CommentList.tsx
+++ b/apps/client/app/community/post/[postId]/components/comment/CommentList.tsx
@@ -11,10 +11,11 @@ interface CommentListProps {
   >;
 }
 
-export default function CommentList(props: CommentListProps) {
-  const { postId, comments, setIsOpenCommentAndReplyManagingBottomDrawer } =
-    props;
-
+function CommentList({
+  postId,
+  comments,
+  setIsOpenCommentAndReplyManagingBottomDrawer,
+}: CommentListProps) {
   return (
     <div className="mt-5 flex flex-col gap-y-[0.7rem]">
       {comments?.length === 0 && <EmptyCommentListItem />}
@@ -33,3 +34,5 @@ export default function CommentList(props: CommentListProps) {
     </div>
   );
 }
+
+export default React.memo(CommentList);

--- a/apps/client/app/community/post/[postId]/components/comment/CommentList.tsx
+++ b/apps/client/app/community/post/[postId]/components/comment/CommentList.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import EmptyCommentListItem from "./EmptyCommentListItem";
 import { CommentInfo } from "@/types/comment";
 import CommentListItem from "./CommentListItem";
-import { commentInfos } from "@/data/mock/commentInfos";
 
 interface CommentListProps {
   postId: string;

--- a/apps/client/app/community/post/[postId]/components/comment/CommentListItem.tsx
+++ b/apps/client/app/community/post/[postId]/components/comment/CommentListItem.tsx
@@ -38,15 +38,21 @@ export default function CommentListItem(props: CommentListItemProps) {
     >
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-x-[0.375rem]">
-          <div className="relative w-[30px] h-[30px]">
-            <Image
-              src={commentInfo.writer.profileImagePathUrl}
-              alt="profileImage"
-              fill
-              quality={100}
-              className="rounded-full"
-            />
-          </div>
+          {commentInfo.writer.profileImagePathUrl ? (
+            <div className="relative w-[30px] h-[30px]">
+              <Image
+                src={commentInfo.writer.profileImagePathUrl}
+                alt="profileImage"
+                fill
+                quality={100}
+                className="rounded-full"
+              />
+            </div>
+          ) : (
+            <span className="w-[30px] h-[30px] flex justify-center items-center bg-[#eee] text-[#4e5968] font-medium rounded-full">
+              {commentInfo.writer.username.charAt(0)}
+            </span>
+          )}
           <span className="text-[0.825rem] text-[#333d4b] font-medium">
             {commentInfo.writer.username}
           </span>

--- a/apps/client/app/community/post/[postId]/page.tsx
+++ b/apps/client/app/community/post/[postId]/page.tsx
@@ -3,7 +3,7 @@
 import { PostInfo } from "@/types/post";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { Toast } from "flowbite-react";
 import ConfirmDeleteCommunityPostModal from "./components/ConfirmDeleteCommunityPostModal";
@@ -183,7 +183,8 @@ export default function CommunityPost(props: DefaultProps) {
   ] = useState<string | undefined>();
 
   const [comment, setComment] = useState<string>("");
-  const [isCommentEditStatus, setIsCommentEditStatus] = useState(false);
+  const [isCommentEditStatus, setIsCommentEditStatus] =
+    useState<boolean>(false);
   const [isNewCommentAdded, setIsNewCommentAdded] = useState<boolean>(false);
 
   const router = useRouter();
@@ -320,16 +321,16 @@ export default function CommunityPost(props: DefaultProps) {
       });
   };
 
+  // 댓글 추가 후 스크롤을 강제로 최하단으로 이동
   useEffect(() => {
     if (isNewCommentAdded) {
-      // DOM이 업데이트된 후에만 스크롤을 수행
       window.scrollTo({
-        top: document.body.scrollHeight,
+        top: document.body.scrollHeight, // 최하단으로 이동
         behavior: "smooth",
       });
-      setIsNewCommentAdded(false);
+      setIsNewCommentAdded(false); // 스크롤 후 플래그 초기화
     }
-  }, [isNewCommentAdded]); // `data`가 업데이트되면 실행됨
+  }, [isNewCommentAdded]);
 
   if (isError) return <NotFound />;
   if (isPending) return <Loading />;
@@ -606,7 +607,7 @@ export default function CommunityPost(props: DefaultProps) {
               </div>
             </div>
 
-            <div className="flex flex-col gap-y-1 px-7 py-2">
+            <div className="flex flex-col gap-y-1 px-7 pt-2 pb-[7.25rem]">
               <p className="flex items-center gap-x-[0.2rem] text-[0.9rem] text-[#333d4b] font-semibold ">
                 댓글
                 <span className="text-[#3a8af9]">


### PR DESCRIPTION
resolve #21 

## Description

서버 측 `커뮤니티 게시글 댓글 작성하기` API를 커뮤니티 게시글 페이지에서
로그인 한 사용자들이 호출할 수 있도록 하는 기능을 추가하였습니다.

- 추가된 `커뮤니티 게시글 댓글 추가` 기능

https://github.com/user-attachments/assets/2e86928b-6cf9-472d-a404-63abdfda6487