### PR TITLE
feat: 커뮤니티 게시글 댓글 수정 API 연동

### DIFF
--- a/apps/client/app/community/post/[postId]/components/comment/CommentList.tsx
+++ b/apps/client/app/community/post/[postId]/components/comment/CommentList.tsx
@@ -6,8 +6,12 @@ import CommentListItem from "./CommentListItem";
 interface CommentListProps {
   postId: string;
   comments: CommentInfo[];
-  setSelectedCommentId: React.Dispatch<React.SetStateAction<number>>;
-  setSelectedReplyId: React.Dispatch<React.SetStateAction<number>>;
+  setSelectedCommentInfo: React.Dispatch<
+    React.SetStateAction<{ commentId: number; commentContent: string }>
+  >;
+  setSelectedReplyInfo: React.Dispatch<
+    React.SetStateAction<{ replyId: number; replyContent: string }>
+  >;
   setIsOpenCommentManagingBottomDrawer: React.Dispatch<
     React.SetStateAction<boolean>
   >;
@@ -19,8 +23,8 @@ interface CommentListProps {
 function CommentList({
   postId,
   comments,
-  setSelectedCommentId,
-  setSelectedReplyId,
+  setSelectedCommentInfo,
+  setSelectedReplyInfo,
   setIsOpenCommentManagingBottomDrawer,
   setIsOpenReplyManagingBottomDrawer,
 }: CommentListProps) {
@@ -34,8 +38,8 @@ function CommentList({
           index={index}
           length={comments.length}
           postId={postId}
-          setSelectedCommentId={setSelectedCommentId}
-          setSelectedReplyId={setSelectedReplyId}
+          setSelectedCommentInfo={setSelectedCommentInfo}
+          setSelectedReplyInfo={setSelectedReplyInfo}
           setIsOpenCommentManagingBottomDrawer={
             setIsOpenCommentManagingBottomDrawer
           }

--- a/apps/client/app/community/post/[postId]/components/comment/CommentListItem.tsx
+++ b/apps/client/app/community/post/[postId]/components/comment/CommentListItem.tsx
@@ -12,8 +12,12 @@ interface CommentListItemProps {
   index: number;
   length: number;
   postId: string;
-  setSelectedCommentId: React.Dispatch<React.SetStateAction<number>>;
-  setSelectedReplyId: React.Dispatch<React.SetStateAction<number>>;
+  setSelectedCommentInfo: React.Dispatch<
+    React.SetStateAction<{ commentId: number; commentContent: string }>
+  >;
+  setSelectedReplyInfo: React.Dispatch<
+    React.SetStateAction<{ replyId: number; replyContent: string }>
+  >;
   setIsOpenCommentManagingBottomDrawer: React.Dispatch<
     React.SetStateAction<boolean>
   >;
@@ -28,8 +32,8 @@ export default function CommentListItem(props: CommentListItemProps) {
     index,
     length,
     postId,
-    setSelectedCommentId,
-    setSelectedReplyId,
+    setSelectedCommentInfo,
+    setSelectedReplyInfo,
     setIsOpenCommentManagingBottomDrawer,
     setIsOpenReplyManagingBottomDrawer,
   } = props;
@@ -72,7 +76,7 @@ export default function CommentListItem(props: CommentListItemProps) {
           {userInfo.memberId === commentInfo.writer.memberId && (
             <button
               onClick={() => {
-                setSelectedCommentId(commentInfo.commentId);
+                setSelectedCommentInfo(commentInfo);
                 setIsOpenCommentManagingBottomDrawer(true);
               }}
               className="p-[0.1rem] rounded-md hover:bg-[#f6f6f6]"
@@ -195,7 +199,7 @@ export default function CommentListItem(props: CommentListItemProps) {
       <ReplyList
         postId={postId}
         commentId={commentInfo.commentId}
-        setSelectedReplyId={setSelectedReplyId}
+        setSelectedReplyInfo={setSelectedReplyInfo}
         replyInfos={commentInfo.replies}
         setIsOpenReplyManagingBottomDrawer={setIsOpenReplyManagingBottomDrawer}
       />

--- a/apps/client/app/community/post/[postId]/components/comment/reply/ReplyList.tsx
+++ b/apps/client/app/community/post/[postId]/components/comment/reply/ReplyList.tsx
@@ -7,7 +7,9 @@ interface ReplyListProps {
   postId: string;
   commentId: number;
   replyInfos: ReplyInfo[];
-  setSelectedReplyId: React.Dispatch<React.SetStateAction<number>>;
+  setSelectedReplyInfo: React.Dispatch<
+    React.SetStateAction<{ replyId: number; replyContent: string }>
+  >;
   setIsOpenReplyManagingBottomDrawer: React.Dispatch<
     React.SetStateAction<boolean>
   >;
@@ -18,7 +20,7 @@ export default function ReplyList(props: ReplyListProps) {
     postId,
     commentId,
     replyInfos,
-    setSelectedReplyId,
+    setSelectedReplyInfo,
     setIsOpenReplyManagingBottomDrawer,
   } = props;
 
@@ -31,7 +33,7 @@ export default function ReplyList(props: ReplyListProps) {
             commentId={commentId}
             replyInfo={replyInfo}
             key={index}
-            setIsSelectedReplyId={setSelectedReplyId}
+            setSelectedReplyInfo={setSelectedReplyInfo}
             setIsOpenReplyManagingBottomDrawer={
               setIsOpenReplyManagingBottomDrawer
             }

--- a/apps/client/app/community/post/[postId]/components/comment/reply/ReplyListItem.tsx
+++ b/apps/client/app/community/post/[postId]/components/comment/reply/ReplyListItem.tsx
@@ -10,7 +10,9 @@ interface ReplyListItemProps {
   postId: string;
   commentId: number;
   replyInfo: ReplyInfo;
-  setIsSelectedReplyId: React.Dispatch<React.SetStateAction<number>>;
+  setSelectedReplyInfo: React.Dispatch<
+    React.SetStateAction<{ replyId: number; replyContent: string }>
+  >;
   setIsOpenReplyManagingBottomDrawer: React.Dispatch<
     React.SetStateAction<boolean>
   >;
@@ -21,7 +23,7 @@ export default function ReplyListItem(props: ReplyListItemProps) {
     postId,
     commentId,
     replyInfo,
-    setIsSelectedReplyId,
+    setSelectedReplyInfo,
     setIsOpenReplyManagingBottomDrawer,
   } = props;
 
@@ -56,7 +58,7 @@ export default function ReplyListItem(props: ReplyListItemProps) {
             {userInfo.memberId === replyInfo.writer.memberId && (
               <button
                 onClick={() => {
-                  setIsSelectedReplyId(replyInfo.replyId);
+                  setSelectedReplyInfo(replyInfo);
                   setIsOpenReplyManagingBottomDrawer(true);
                 }}
                 className="p-[0.1rem] rounded-md hover:bg-[#f6f6f6]"


### PR DESCRIPTION
resolve #25 

## Description

서버 측 `커뮤니티 게시글 댓글 수정하기` API를 커뮤니티 게시글 페이지에서
로그인 한 사용자들이 호출할 수 있도록 하는 기능을 추가하였습니다.

- 추가된 `댓글 수정하기` 기능 사용 화면

https://github.com/user-attachments/assets/88336603-0109-4d74-88e1-ec8286283db5