### PR TITLE
chore: 프론트 측 커뮤니티 게시글 삭제/수정 API 요청 URL 변경

### DIFF
--- a/apps/client/app/community/post/[postId]/components/ConfirmDeleteCommunityPostModal.tsx
+++ b/apps/client/app/community/post/[postId]/components/ConfirmDeleteCommunityPostModal.tsx
@@ -12,7 +12,7 @@ import { ToastInfoStore } from "@/store/components/ToastInfo";
 
 // 커뮤니티 게시글 삭제 API
 const deleteCommunityPost = (postId: string) => {
-  return axiosInstance.delete(`/private/community/${postId}`);
+  return axiosInstance.delete(`/private/community/posts/${postId}`);
 };
 
 interface ConfirmDeleteCommunityPostModalProps {

--- a/apps/client/app/community/post/[postId]/edit/page.tsx
+++ b/apps/client/app/community/post/[postId]/edit/page.tsx
@@ -30,7 +30,7 @@ const modifyCommunityPost = ({
   postId: string;
   requestBody: CreatePostParams;
 }) => {
-  return axiosInstance.put(`/private/community/${postId}`, requestBody);
+  return axiosInstance.put(`/private/community/posts/${postId}`, requestBody);
 };
 
 interface DefaultProps {


### PR DESCRIPTION
resolve #39 

## Description

서버 측 커뮤니티 게시글 삭제/수정 API의 엔드포인트가 변경됨에 따라 기존
프론트 측에서 해당 API 요청을 위해 작성한 URL를 변경된 엔드포인트를 가리키도록
수정하였습니다.