### PR TITLE
fix: 댓글 삭제 시 답글이 존재하면 500 에러 대신 409 에러를 반환하도록 수정

### DIFF
--- a/apps/server/src/main/java/com/example/exception/ErrorCode.java
+++ b/apps/server/src/main/java/com/example/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     PARTY_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "시작된 파티의 모집 인원은 변경할 수 없습니다."),
     INVALID_SERVICE_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 서비스입니다."),
     LEADER_CANNOT_LEAVE_PARTY(HttpStatus.BAD_REQUEST, "파티장은 파티를 탈퇴할 수 없습니다."),
-    
+
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 없습니다. 다시 로그인 하세요"),
 
@@ -51,6 +51,7 @@ public enum ErrorCode {
     ALREADY_COMMENT_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 댓글입니다."),
     ALREADY_REPLY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 답글입니다."),
     ALREADY_PAYMENT_KEY(HttpStatus.CONFLICT, "이미 존재하는 결제 키입니다."),
+    COMMENT_HAS_REPLIES(HttpStatus.CONFLICT, "해당 댓글에 답글이 있어 삭제할 수 없습니다."),
 
     // 500 INTERNAL_SERVER_ERROR
     UPLOAD_DIRECTORY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "업로드 디렉토리를 생성할 수 없습니다."),

--- a/apps/server/src/main/java/com/example/repository/community/ReplyRepository.java
+++ b/apps/server/src/main/java/com/example/repository/community/ReplyRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
     int countByCommentPostId(Long postId);
     List<Reply> findByCommentId(Long commentId);
+    boolean existsByCommentId(Long commentId);
 }

--- a/apps/server/src/main/java/com/example/service/community/CommentService.java
+++ b/apps/server/src/main/java/com/example/service/community/CommentService.java
@@ -12,6 +12,7 @@ import com.example.exception.ErrorCode;
 import com.example.repository.community.CommentRepository;
 import com.example.repository.community.PostRepository;
 import com.example.repository.community.CommentLikeRepository;
+import com.example.repository.community.ReplyRepository;
 import com.example.repository.member.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class CommentService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final CommentLikeRepository commentLikeRepository;
+    private final ReplyRepository ReplyRepository;
 
     private final TokenProvider tokenProvider;
 
@@ -68,6 +70,11 @@ public class CommentService {
     public ApiResult<?> deleteComment(Long commentId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        if (ReplyRepository.existsByCommentId(commentId)) {
+          throw new CustomException(ErrorCode.COMMENT_HAS_REPLIES);
+        }
+
         commentRepository.delete(comment);
         return ApiResult.success("댓글이 삭제되었습니다.");
     }


### PR DESCRIPTION
resolve #43

## Description

댓글 삭제 시 답글 존재 여부를 확인하는 로직 추가
답글이 있는 경우 409 에러를 발생시키는 예외 처리 구현