### PR TITLE
fix: 태그 구독 취소하기 오류 해결

### DIFF
--- a/apps/server/src/main/java/com/example/controller/subscribe/SubscribeController.java
+++ b/apps/server/src/main/java/com/example/controller/subscribe/SubscribeController.java
@@ -27,7 +27,7 @@ public class SubscribeController {
     }
 
     @Operation(summary = "태그 구독 취소하기", description = "")
-    @DeleteMapping("/tags//{tagId}")
+    @DeleteMapping("/tags/{tagId}")
     public ApiResult<?> unsubscribeTag(HttpServletRequest request, @PathVariable Long tagId) {
         return subscribeService.unsubscribeTag(request, tagId);
     }


### PR DESCRIPTION
resolve #47

## Description
태그 구독 취소하기 API 요청 시 모든 응답에서 405 에러가 발생하므로 해당 이슈 해결했습니다.