### PR TITLE
회원의 구독한 태그 페이지 내 관련 APIs 연동 작업 수행

### DIFF
--- a/apps/client/app/community/my/subscribed-tags/components/subscribedTag/EmptySubscribedTagListItem.tsx
+++ b/apps/client/app/community/my/subscribed-tags/components/subscribedTag/EmptySubscribedTagListItem.tsx
@@ -1,15 +1,18 @@
-import React from 'react';
+import Image from "next/image";
+import React from "react";
+import warningGrayImg from "@/public/images/warning_icon_gray.png";
 
 export default function EmptySubscribedTagListItem() {
   return (
-    <tr className='border-b dark:border-gray-700 text-xs text-center'>
-      <th
-        scope='row'
-        className='px-4 py-3 font-medium text-gray-900 whitespace-nowrap dark:text-white'
-      >
-        1
-      </th>
-      <td className='text-sm'>태그 정보가 없습니다</td>
-    </tr>
+    <div className="mt-20 w-full flex flex-col gap-y-3 items-center">
+      <Image
+        src={warningGrayImg}
+        alt="warning icon image"
+        width={35}
+        height={35}
+        quality={100}
+      />
+      <p className="text-[#9b9b9b] text-xs">태그 정보가 없습니다</p>
+    </div>
   );
 }

--- a/apps/client/app/community/my/subscribed-tags/components/subscribedTag/SubscribedTagList.tsx
+++ b/apps/client/app/community/my/subscribed-tags/components/subscribedTag/SubscribedTagList.tsx
@@ -1,23 +1,19 @@
-'use client';
+"use client";
 
-import React, { useEffect } from 'react';
-import Loading from '@/app/loading';
-import axiosInstance from '@/utils/axiosInstance';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
-import { MySubscribedTagInfo } from '@/types/tag';
-import SubscribedTagListItem from './SubscribedTagListItem';
-import EmptySubscribedTagListItem from './EmptySubscribedTagListItem';
-import UnSubscribedTagListItem from './UnSubscribedTagListItem';
+import React, { useEffect } from "react";
+import Loading from "@/app/loading";
+import axiosInstance from "@/utils/axiosInstance";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { MySubscribedTagInfo } from "@/types/tag";
+import SubscribedTagListItem from "./SubscribedTagListItem";
+import EmptySubscribedTagListItem from "./EmptySubscribedTagListItem";
+import UnSubscribedTagListItem from "./UnSubscribedTagListItem";
 
 interface SubscribedTagListProps {
-  resData: MySubscribedTagInfo[];
-  setResData: React.Dispatch<React.SetStateAction<MySubscribedTagInfo[]>>;
-  setIsOpenSubscribeCompleteToast: React.Dispatch<
-    React.SetStateAction<boolean>
-  >;
-  setIsOpenUnSubscribeCompleteToast: React.Dispatch<
-    React.SetStateAction<boolean>
+  mySubscribedTagInfos: MySubscribedTagInfo[];
+  setMySubscribedTagInfos: React.Dispatch<
+    React.SetStateAction<MySubscribedTagInfo[]>
   >;
   setIsOpenBottomDrawer: React.Dispatch<React.SetStateAction<boolean>>;
   selectedTagInfo: {
@@ -34,65 +30,40 @@ interface SubscribedTagListProps {
   >;
 }
 
-// 시험 목록 반환 API (10개 게시글 단위로)
-// const fetchExams = async ({ queryKey }: any) => {
-//   const page = queryKey[1];
-//   const searchQuery = queryKey[2];
-//   const response = await axiosInstance.get(
-//     `${process.env.NEXT_PUBLIC_API_VERSION}/assignment/?page=${page}&limit=10&sort=-createdAt&q=title,course,writer=${searchQuery}`
-//   );
-//   return response.data;
-// };
-
 export default function SubscribedTagList(props: SubscribedTagListProps) {
   const {
-    resData,
-    setResData,
-    setIsOpenSubscribeCompleteToast,
-    setIsOpenUnSubscribeCompleteToast,
+    mySubscribedTagInfos,
+    setMySubscribedTagInfos,
     setIsOpenBottomDrawer,
     selectedTagInfo,
     setSelectedTagInfo,
   } = props;
 
-  const params = useSearchParams();
-
-  // const { isPending, data } = useQuery({
-  //   queryKey: ['examList', page, debouncedSearchQuery],
-  //   queryFn: fetchExams,
-  // });
-
   const router = useRouter();
 
-  // const resData = data?.data;
-
-  // if (isPending) return <Loading />;
+  if (mySubscribedTagInfos.length === 0) return <EmptySubscribedTagListItem />;
 
   return (
-    <div className='flex flex-col gap-y-3'>
-      {resData?.length === 0 && <EmptySubscribedTagListItem />}
-      {resData?.map((mySubscribedTagInfo: MySubscribedTagInfo, index: number) =>
-        mySubscribedTagInfo.isSubscribed ? (
-          <SubscribedTagListItem
-            key={index}
-            mySubscribedTagInfo={mySubscribedTagInfo}
-            setIsOpenBottomDrawer={setIsOpenBottomDrawer}
-            selectedTagInfo={selectedTagInfo}
-            setSelectedTagInfo={setSelectedTagInfo}
-          />
-        ) : (
-          <UnSubscribedTagListItem
-            key={index}
-            setResData={setResData}
-            mySubscribedTagInfo={mySubscribedTagInfo}
-            selectedTagInfo={selectedTagInfo}
-            setSelectedTagInfo={setSelectedTagInfo}
-            setIsOpenSubscribeCompleteToast={setIsOpenSubscribeCompleteToast}
-            setIsOpenUnSubscribeCompleteToast={
-              setIsOpenUnSubscribeCompleteToast
-            }
-          />
-        )
+    <div className="flex flex-col gap-y-3">
+      {mySubscribedTagInfos.map(
+        (mySubscribedTagInfo: MySubscribedTagInfo, index: number) =>
+          mySubscribedTagInfo.isSubscribed ? (
+            <SubscribedTagListItem
+              key={index}
+              mySubscribedTagInfo={mySubscribedTagInfo}
+              setIsOpenBottomDrawer={setIsOpenBottomDrawer}
+              selectedTagInfo={selectedTagInfo}
+              setSelectedTagInfo={setSelectedTagInfo}
+            />
+          ) : (
+            <UnSubscribedTagListItem
+              key={index}
+              setMySubscribedTagInfos={setMySubscribedTagInfos}
+              mySubscribedTagInfo={mySubscribedTagInfo}
+              selectedTagInfo={selectedTagInfo}
+              setSelectedTagInfo={setSelectedTagInfo}
+            />
+          )
       )}
     </div>
   );

--- a/apps/client/app/community/my/subscribed-tags/components/subscribedTag/SubscribedTagListItem.tsx
+++ b/apps/client/app/community/my/subscribed-tags/components/subscribedTag/SubscribedTagListItem.tsx
@@ -1,5 +1,6 @@
-import { MySubscribedTagInfo } from '@/types/tag';
-import Link from 'next/link';
+import { ToastInfoStore } from "@/store/components/ToastInfo";
+import { MySubscribedTagInfo } from "@/types/tag";
+import Link from "next/link";
 
 interface SubscribedTagListItemProps {
   mySubscribedTagInfo: MySubscribedTagInfo;
@@ -27,34 +28,34 @@ export default function SubscribedTagListItem(
   return (
     <Link
       href={`/community/feed?tag=${mySubscribedTagInfo.tag}`}
-      className='w-full flex justify-between items-center bg-[#f9fafb] p-4 rounded-md'
+      className="w-full flex justify-between items-center bg-[#f9fafb] p-4 rounded-md"
     >
-      <div className='flex items-center gap-x-3'>
+      <div className="flex items-center gap-x-3">
         <div
-          className='w-fit flex justify-center items-center p-1 rounded-full'
-          style={{ background: 'rgba(2, 32, 71, 0.05' }}
+          className="w-fit flex justify-center items-center p-1 rounded-full"
+          style={{ background: "rgba(2, 32, 71, 0.05" }}
         >
           <svg
-            width='24'
-            height='24'
-            fill='none'
-            xmlns='http://www.w3.org/2000/svg'
-            viewBox='0 0 24 24'
-            data-v-9b82dcfc=''
-            className=''
+            width="24"
+            height="24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            data-v-9b82dcfc=""
+            className=""
           >
             <path
-              fillRule='evenodd'
-              clipRule='evenodd'
-              d='M10.216 5.015a1 1 0 00-1.159.812L8.69 7.909H7a1 1 0 100 2h1.337l-.705 4H6a1 1 0 100 2h1.28l-.307 1.735a1 1 0 001.97.348l.367-2.083h3.969l-.306 1.735a1 1 0 101.97.348l.367-2.083H17a1 1 0 100-2h-1.338l.705-4h1.634a1 1 0 100-2h-1.28l.305-1.735a1 1 0 10-1.97-.347l-.367 2.082h-3.968l.306-1.735a1 1 0 00-.811-1.159zm3.415 8.894l.706-4h-3.969l-.705 4h3.968z'
-              fill='#98A4B7'
-              data-v-9b82dcfc=''
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M10.216 5.015a1 1 0 00-1.159.812L8.69 7.909H7a1 1 0 100 2h1.337l-.705 4H6a1 1 0 100 2h1.28l-.307 1.735a1 1 0 001.97.348l.367-2.083h3.969l-.306 1.735a1 1 0 101.97.348l.367-2.083H17a1 1 0 100-2h-1.338l.705-4h1.634a1 1 0 100-2h-1.28l.305-1.735a1 1 0 10-1.97-.347l-.367 2.082h-3.968l.306-1.735a1 1 0 00-.811-1.159zm3.415 8.894l.706-4h-3.969l-.705 4h3.968z"
+              fill="#98A4B7"
+              data-v-9b82dcfc=""
             ></path>
           </svg>
         </div>
-        <div className='flex flex-col items-start text-[#333d4b] font-medium'>
-          <span className='text-sm'>{mySubscribedTagInfo.tag}</span>
-          <span className='text-xs font-light'>게시글 3개</span>
+        <div className="flex flex-col items-start text-[#333d4b] font-medium">
+          <span className="text-sm">{mySubscribedTagInfo.tag}</span>
+          <span className="text-xs font-light">게시글 3개</span>
         </div>
       </div>
 
@@ -64,42 +65,42 @@ export default function SubscribedTagListItem(
           setSelectedTagInfo(mySubscribedTagInfo);
           setIsOpenBottomDrawer(true);
         }}
-        className='relative w-24 flex justify-center items-center gap-x-[0.175rem] px-7 py-2 rounded-full border border-[#3a8af9]'
+        className="relative w-24 flex justify-center items-center gap-x-[0.175rem] px-7 py-2 rounded-full border border-[#3a8af9]"
       >
         {mySubscribedTagInfo.isReceiveNotification ? (
           <svg
-            xmlns='http://www.w3.org/2000/svg'
-            height='17.5'
-            viewBox='0 -960 960 960'
-            width='17.5'
-            fill='#3a8af9'
-            className='absolute left-[0.6rem]'
+            xmlns="http://www.w3.org/2000/svg"
+            height="17.5"
+            viewBox="0 -960 960 960"
+            width="17.5"
+            fill="#3a8af9"
+            className="absolute left-[0.6rem]"
           >
-            <path d='M200-200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-83 50-147.5T420-792v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 84.5T720-560v280h40q17 0 28.5 11.5T800-240q0 17-11.5 28.5T760-200H200ZM480-80q-33 0-56.5-23.5T400-160h160q0 33-23.5 56.5T480-80Z' />
+            <path d="M200-200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-83 50-147.5T420-792v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 84.5T720-560v280h40q17 0 28.5 11.5T800-240q0 17-11.5 28.5T760-200H200ZM480-80q-33 0-56.5-23.5T400-160h160q0 33-23.5 56.5T480-80Z" />
           </svg>
         ) : (
           <svg
-            xmlns='http://www.w3.org/2000/svg'
-            height='17.5'
-            viewBox='0 -960 960 960'
-            width='17.5'
-            fill='#3a8af9'
-            className='absolute left-[0.6rem]'
+            xmlns="http://www.w3.org/2000/svg"
+            height="17.5"
+            viewBox="0 -960 960 960"
+            width="17.5"
+            fill="#3a8af9"
+            className="absolute left-[0.6rem]"
           >
-            <path d='M646-200H200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-33 8.5-65t25.5-61l126 126H288L84-764q-11-11-11-28t11-28q11-11 28-11t28 11l680 680q11 11 11.5 27.5T820-84q-11 11-28 11t-28-11L646-200Zm74-251q0 12-7 22t-18 15q-11 5-23 2.5T652-422L367-707q-7-7-10-15t-3-17q0-11 5.5-21.5T375-776q11-5 22-9t23-7v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 85t50 147v109ZM480-80q-30 0-53.5-16.5T403-141q0-8 6.5-13.5T424-160h112q8 0 14.5 5.5T557-141q0 28-23.5 44.5T480-80Z' />
+            <path d="M646-200H200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-33 8.5-65t25.5-61l126 126H288L84-764q-11-11-11-28t11-28q11-11 28-11t28 11l680 680q11 11 11.5 27.5T820-84q-11 11-28 11t-28-11L646-200Zm74-251q0 12-7 22t-18 15q-11 5-23 2.5T652-422L367-707q-7-7-10-15t-3-17q0-11 5.5-21.5T375-776q11-5 22-9t23-7v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 85t50 147v109ZM480-80q-30 0-53.5-16.5T403-141q0-8 6.5-13.5T424-160h112q8 0 14.5 5.5T557-141q0 28-23.5 44.5T480-80Z" />
           </svg>
         )}
 
-        <span className='text-[0.8rem] font-medium text-[#3a8af9]'>구독중</span>
+        <span className="text-[0.8rem] font-medium text-[#3a8af9]">구독중</span>
         <svg
-          xmlns='http://www.w3.org/2000/svg'
-          height='25'
-          viewBox='0 -960 960 960'
-          width='25'
-          fill='#3a8af9'
-          className='absolute right-[0.375rem]'
+          xmlns="http://www.w3.org/2000/svg"
+          height="25"
+          viewBox="0 -960 960 960"
+          width="25"
+          fill="#3a8af9"
+          className="absolute right-[0.375rem]"
         >
-          <path d='M480-372.92q-7.23 0-13.46-2.31t-11.85-7.92L274.92-562.92q-8.3-8.31-8.5-20.89-.19-12.57 8.5-21.27 8.7-8.69 21.08-8.69 12.38 0 21.08 8.69L480-442.15l162.92-162.93q8.31-8.3 20.89-8.5 12.57-.19 21.27 8.5 8.69 8.7 8.69 21.08 0 12.38-8.69 21.08L505.31-383.15q-5.62 5.61-11.85 7.92-6.23 2.31-13.46 2.31Z' />
+          <path d="M480-372.92q-7.23 0-13.46-2.31t-11.85-7.92L274.92-562.92q-8.3-8.31-8.5-20.89-.19-12.57 8.5-21.27 8.7-8.69 21.08-8.69 12.38 0 21.08 8.69L480-442.15l162.92-162.93q8.31-8.3 20.89-8.5 12.57-.19 21.27 8.5 8.69 8.7 8.69 21.08 0 12.38-8.69 21.08L505.31-383.15q-5.62 5.61-11.85 7.92-6.23 2.31-13.46 2.31Z" />
         </svg>
       </button>
     </Link>

--- a/apps/client/app/community/my/subscribed-tags/components/subscribedTag/UnSubscribedTagListItem.tsx
+++ b/apps/client/app/community/my/subscribed-tags/components/subscribedTag/UnSubscribedTagListItem.tsx
@@ -1,8 +1,19 @@
-import { MySubscribedTagInfo } from '@/types/tag';
-import Link from 'next/link';
+import { ToastInfoStore } from "@/store/components/ToastInfo";
+import { MySubscribedTagInfo } from "@/types/tag";
+import axiosInstance from "@/utils/axiosInstance";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import Link from "next/link";
+
+// 태그 구독하기 API
+const subscribeTag = (tagId: number) => {
+  return axiosInstance.post(`/private/subscribe/tags/${tagId}`);
+};
 
 interface UnSubscribedTagListItemProps {
-  setResData: React.Dispatch<React.SetStateAction<MySubscribedTagInfo[]>>;
+  setMySubscribedTagInfos: React.Dispatch<
+    React.SetStateAction<MySubscribedTagInfo[]>
+  >;
   mySubscribedTagInfo: MySubscribedTagInfo;
   selectedTagInfo: {
     tagId: number;
@@ -15,96 +26,127 @@ interface UnSubscribedTagListItemProps {
       isReceiveNotification: boolean;
     }>
   >;
-  setIsOpenSubscribeCompleteToast: React.Dispatch<
-    React.SetStateAction<boolean>
-  >;
-  setIsOpenUnSubscribeCompleteToast: React.Dispatch<
-    React.SetStateAction<boolean>
-  >;
 }
 
 export default function UnSubscribedTagListItem(
   props: UnSubscribedTagListItemProps
 ) {
   const {
-    setResData,
+    setMySubscribedTagInfos,
     mySubscribedTagInfo,
     selectedTagInfo,
     setSelectedTagInfo,
-    setIsOpenSubscribeCompleteToast,
-    setIsOpenUnSubscribeCompleteToast,
   } = props;
+  const queryClient = useQueryClient();
+
+  const updateToastMessage = ToastInfoStore(
+    (state: any) => state.updateToastMessage
+  );
+  const updateOpenToastStatus = ToastInfoStore(
+    (state: any) => state.updateOpenToastStatus
+  );
+
+  const subscribeTagMutation = useMutation({
+    mutationFn: subscribeTag,
+    onMutate: () => {},
+    onError: (error: AxiosError) => {
+      const resData: any = error.response;
+
+      switch (resData?.status) {
+        case 409:
+          switch (resData?.data.error.status) {
+            default:
+              alert("정의되지 않은 http code입니다.");
+          }
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
+    },
+    onSuccess: (data) => {
+      const httpStatusCode = data.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          // 쿼리 데이터 업데이트
+          queryClient.invalidateQueries({
+            queryKey: ["mySubscribedTagInfos"],
+          });
+          updateToastMessage(
+            `"${mySubscribedTagInfo.tag}" 구독이 완료되었습니다`
+          );
+          updateOpenToastStatus(true);
+
+          setMySubscribedTagInfos((prevData) =>
+            prevData.map((item) =>
+              item.tagId === selectedTagInfo.tagId
+                ? {
+                    ...item,
+                    isSubscribed: false,
+                  }
+                : item
+            )
+          );
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
+    },
+    onSettled: () => {},
+  });
 
   return (
     <Link
       href={`/community/feed?tag=${mySubscribedTagInfo.tag}`}
-      className='w-full flex justify-between items-center bg-[#f9fafb] p-4 rounded-md'
+      className="w-full flex justify-between items-center bg-[#f9fafb] p-4 rounded-md"
     >
-      <div className='flex items-center gap-x-3'>
+      <div className="flex items-center gap-x-3">
         <div
-          className='w-fit flex justify-center items-center p-1 rounded-full'
-          style={{ background: 'rgba(2, 32, 71, 0.05' }}
+          className="w-fit flex justify-center items-center p-1 rounded-full"
+          style={{ background: "rgba(2, 32, 71, 0.05" }}
         >
           <svg
-            width='24'
-            height='24'
-            fill='none'
-            xmlns='http://www.w3.org/2000/svg'
-            viewBox='0 0 24 24'
-            data-v-9b82dcfc=''
-            className=''
+            width="24"
+            height="24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            data-v-9b82dcfc=""
+            className=""
           >
             <path
-              fillRule='evenodd'
-              clipRule='evenodd'
-              d='M10.216 5.015a1 1 0 00-1.159.812L8.69 7.909H7a1 1 0 100 2h1.337l-.705 4H6a1 1 0 100 2h1.28l-.307 1.735a1 1 0 001.97.348l.367-2.083h3.969l-.306 1.735a1 1 0 101.97.348l.367-2.083H17a1 1 0 100-2h-1.338l.705-4h1.634a1 1 0 100-2h-1.28l.305-1.735a1 1 0 10-1.97-.347l-.367 2.082h-3.968l.306-1.735a1 1 0 00-.811-1.159zm3.415 8.894l.706-4h-3.969l-.705 4h3.968z'
-              fill='#98A4B7'
-              data-v-9b82dcfc=''
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M10.216 5.015a1 1 0 00-1.159.812L8.69 7.909H7a1 1 0 100 2h1.337l-.705 4H6a1 1 0 100 2h1.28l-.307 1.735a1 1 0 001.97.348l.367-2.083h3.969l-.306 1.735a1 1 0 101.97.348l.367-2.083H17a1 1 0 100-2h-1.338l.705-4h1.634a1 1 0 100-2h-1.28l.305-1.735a1 1 0 10-1.97-.347l-.367 2.082h-3.968l.306-1.735a1 1 0 00-.811-1.159zm3.415 8.894l.706-4h-3.969l-.705 4h3.968z"
+              fill="#98A4B7"
+              data-v-9b82dcfc=""
             ></path>
           </svg>
         </div>
-        <div className='flex flex-col items-start text-[#333d4b] font-medium'>
-          <span className='text-sm'>{mySubscribedTagInfo.tag}</span>
-          <span className='text-xs font-light'>게시글 3개</span>
+        <div className="flex flex-col items-start text-[#333d4b] font-medium">
+          <span className="text-sm">{mySubscribedTagInfo.tag}</span>
+          <span className="text-xs font-light">게시글 3개</span>
         </div>
       </div>
 
       <button
         onClick={(e) => {
           e.preventDefault();
-          setIsOpenSubscribeCompleteToast(false);
-          setIsOpenUnSubscribeCompleteToast(false);
-
-          setTimeout(() => {
-            setIsOpenSubscribeCompleteToast(true);
-          }, 50);
-
-          setSelectedTagInfo(mySubscribedTagInfo);
-
-          setResData((prevData) =>
-            prevData.map((item) =>
-              item.tagId === mySubscribedTagInfo.tagId
-                ? {
-                    ...item,
-                    isSubscribed: true,
-                  }
-                : item
-            )
-          );
+          subscribeTagMutation.mutate(mySubscribedTagInfo.tagId);
         }}
-        className='relative w-24 flex justify-center items-center gap-x-[0.175rem] px-7 py-2 rounded-full bg-[#3a8af9] border border-[#3a8af9]'
+        className="relative w-24 flex justify-center items-center gap-x-[0.175rem] px-7 py-2 rounded-full bg-[#3a8af9] border border-[#3a8af9]"
       >
         <svg
-          xmlns='http://www.w3.org/2000/svg'
-          height='17.5'
-          viewBox='0 -960 960 960'
-          width='17.5'
-          fill='white'
-          className='absolute left-[0.6rem]'
+          xmlns="http://www.w3.org/2000/svg"
+          height="17.5"
+          viewBox="0 -960 960 960"
+          width="17.5"
+          fill="white"
+          className="absolute left-[0.6rem]"
         >
-          <path d='M200-200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-83 50-147.5T420-792v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 84.5T720-560v280h40q17 0 28.5 11.5T800-240q0 17-11.5 28.5T760-200H200ZM480-80q-33 0-56.5-23.5T400-160h160q0 33-23.5 56.5T480-80Z' />
+          <path d="M200-200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-83 50-147.5T420-792v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 84.5T720-560v280h40q17 0 28.5 11.5T800-240q0 17-11.5 28.5T760-200H200ZM480-80q-33 0-56.5-23.5T400-160h160q0 33-23.5 56.5T480-80Z" />
         </svg>
-        <span className='ml-3 text-[0.8rem] font-medium text-white whitespace-nowrap'>
+        <span className="ml-3 text-[0.8rem] font-medium text-white whitespace-nowrap">
           구독하기
         </span>
       </button>

--- a/apps/client/app/community/my/subscribed-tags/page.tsx
+++ b/apps/client/app/community/my/subscribed-tags/page.tsx
@@ -1,26 +1,220 @@
-'use client';
+"use client";
 
-import SubscribedTagList from './components/subscribedTag/SubscribedTagList';
-import { useEffect, useRef, useState } from 'react';
-import { Toast } from 'flowbite-react';
-import { useRouter } from 'next/navigation';
-import { mySubScribedTagInfos } from '@/data/mock/tagInfos';
+import SubscribedTagList from "./components/subscribedTag/SubscribedTagList";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ToastInfoStore } from "@/store/components/ToastInfo";
+import axiosInstance from "@/utils/axiosInstance";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { MySubscribedTagInfo, TagInfo } from "@/types/tag";
+import Loading from "@/app/loading";
+import { AxiosError } from "axios";
+
+// 회원의 구독한 태그 목록 정보 조회 API
+const fetchMySubscribedTagInfos = () => {
+  return axiosInstance.get(`/private/subscribe/my/subscribed-tags`);
+};
+
+// 태그 구독 취소하기 API
+const unsubscribeTag = (tagId: number) => {
+  return axiosInstance.delete(`/private/subscribe/tags/${tagId}`);
+};
+
+// 태그 새 글 알림 활성화 API
+const enableReceiveNotification = (tagId: number) => {
+  return axiosInstance.post(`/private/subscribe/tags/${tagId}/notification`);
+};
+
+// 태그 새 글 알림 비활성화 API
+const disableReceiveNotification = (tagId: number) => {
+  return axiosInstance.delete(`/private/subscribe/tags/${tagId}/notification`);
+};
 
 export default function MySubscribedTags() {
-  const resLawData = mySubScribedTagInfos;
+  const queryClient = useQueryClient();
 
-  const [resData, setResData] = useState(
-    resLawData.map((item) => ({
-      ...item,
-      isSubscribed: true,
-    }))
+  const updateToastMessage = ToastInfoStore(
+    (state: any) => state.updateToastMessage
+  );
+  const updateOpenToastStatus = ToastInfoStore(
+    (state: any) => state.updateOpenToastStatus
   );
 
+  const { isPending, isError, data, error } = useQuery({
+    queryKey: ["mySubscribedTagInfos"],
+    queryFn: fetchMySubscribedTagInfos,
+    retry: 0,
+  });
+
+  const unsubscribeTagMutation = useMutation({
+    mutationFn: unsubscribeTag,
+    onMutate: () => {},
+    onError: (error: AxiosError) => {
+      const resData: any = error.response;
+
+      switch (resData?.status) {
+        case 409:
+          switch (resData?.data.error.status) {
+            default:
+              alert("정의되지 않은 http code입니다.");
+          }
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
+    },
+    onSuccess: (data) => {
+      const httpStatusCode = data.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          updateToastMessage(`"${selectedTagInfo.tag}" 구독이 취소되었습니다`);
+          updateOpenToastStatus(true);
+
+          setMySubscribedTagInfos((prevData) =>
+            prevData.map((item) =>
+              item.tagId === selectedTagInfo.tagId
+                ? {
+                    ...item,
+                    isSubscribed: false,
+                  }
+                : item
+            )
+          );
+
+          closeDrawer();
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
+    },
+    onSettled: () => {},
+  });
+
+  const enableReceiveNotificationMutation = useMutation({
+    mutationFn: enableReceiveNotification,
+    onMutate: () => {},
+    onError: (error: AxiosError) => {
+      const resData: any = error.response;
+
+      switch (resData?.status) {
+        case 409:
+          switch (resData?.data.error.status) {
+            case "CONFLICT":
+              alert("이미 알림이 활성화되어 있어요");
+              handleButtonInBottomDrawaberClick();
+              break;
+            default:
+              alert("정의되지 않은 http code입니다.");
+          }
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
+    },
+    onSuccess: (data) => {
+      const httpStatusCode = data.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          // 쿼리 데이터 업데이트
+          queryClient.invalidateQueries({
+            queryKey: ["mySubscribedTagInfos"],
+          });
+
+          setMySubscribedTagInfos((prevData) =>
+            prevData.map((item) =>
+              item.tagId === selectedTagInfo.tagId
+                ? {
+                    ...item,
+                    isReceiveNotification: true,
+                  }
+                : item
+            )
+          );
+          setSelectedTagInfo((prev) => ({
+            ...prev,
+            isReceiveNotification: true,
+          }));
+          handleButtonInBottomDrawaberClick();
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
+    },
+    onSettled: () => {},
+  });
+
+  const disableReceiveNotificationMutation = useMutation({
+    mutationFn: disableReceiveNotification,
+    onMutate: () => {},
+    onError: (error: AxiosError) => {
+      const resData: any = error.response;
+
+      switch (resData?.status) {
+        case 409:
+          switch (resData?.data.error.status) {
+            case "CONFLICT":
+              alert("이미 알림이 비활성화되어 있어요");
+              handleButtonInBottomDrawaberClick();
+              break;
+            default:
+              alert("정의되지 않은 http code입니다.");
+          }
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
+    },
+    onSuccess: (data) => {
+      const httpStatusCode = data.status;
+
+      switch (httpStatusCode) {
+        case 200:
+          // 쿼리 데이터 업데이트
+          queryClient.invalidateQueries({
+            queryKey: ["mySubscribedTagInfos"],
+          });
+
+          setMySubscribedTagInfos((prevData) =>
+            prevData.map((item) =>
+              item.tagId === selectedTagInfo.tagId
+                ? {
+                    ...item,
+                    isReceiveNotification: false,
+                  }
+                : item
+            )
+          );
+          setSelectedTagInfo((prev) => ({
+            ...prev,
+            isReceiveNotification: true,
+          }));
+          handleButtonInBottomDrawaberClick();
+          break;
+        default:
+          alert("정의되지 않은 http status code입니다");
+      }
+    },
+    onSettled: () => {},
+  });
+
+  const [mySubscribedTagInfos, setMySubscribedTagInfos] = useState<
+    MySubscribedTagInfo[]
+  >([]);
+
+  useEffect(() => {
+    if (data) {
+      const resData = data?.data.response.map((item: MySubscribedTagInfo) => ({
+        ...item,
+        isSubscribed: true,
+        isReceiveNotification: item.isReceiveNotification,
+      }));
+      setMySubscribedTagInfos(resData);
+    }
+  }, [data]);
+
   const [isToastClosing, setIsToastClosing] = useState(false);
-  const [isOpenSubscribeCompleteToast, setIsOpenSubscribeCompleteToast] =
-    useState<boolean>(false);
-  const [isOpenUnSubscribeCompleteToast, setIsOpenUnSubscribeCompleteToast] =
-    useState<boolean>(false);
   const [isOpenBottomDrawer, setIsOpenBottomDrawer] = useState<boolean>(false);
   const [isBottomDrawerClosing, setIsBottomDrawerClosing] =
     useState<boolean>(false);
@@ -30,7 +224,7 @@ export default function MySubscribedTags() {
     isReceiveNotification: boolean;
   }>({
     tagId: 0,
-    tag: '',
+    tag: "",
     isReceiveNotification: false,
   });
 
@@ -49,22 +243,22 @@ export default function MySubscribedTags() {
     };
 
     const handleEscKeyPress = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (event.key === "Escape") {
         closeDrawer();
       }
     };
 
     if (isOpenBottomDrawer) {
-      document.addEventListener('click', handleClickOutside);
-      document.addEventListener('keydown', handleEscKeyPress);
+      document.addEventListener("click", handleClickOutside);
+      document.addEventListener("keydown", handleEscKeyPress);
     } else {
-      document.removeEventListener('click', handleClickOutside);
-      document.removeEventListener('keydown', handleEscKeyPress);
+      document.removeEventListener("click", handleClickOutside);
+      document.removeEventListener("keydown", handleEscKeyPress);
     }
 
     return () => {
-      document.removeEventListener('click', handleClickOutside);
-      document.removeEventListener('keydown', handleEscKeyPress);
+      document.removeEventListener("click", handleClickOutside);
+      document.removeEventListener("keydown", handleEscKeyPress);
     };
   }, [isOpenBottomDrawer]);
 
@@ -82,197 +276,122 @@ export default function MySubscribedTags() {
     }, 250);
   };
 
-  useEffect(() => {
-    if (isOpenSubscribeCompleteToast) {
-      const fadeOutTimer = setTimeout(() => {
-        setIsToastClosing(true);
-      }, 3000); // 3초 후에 toast-fade-out 클래스 추가
-
-      const closeTimer = setTimeout(() => {
-        setIsOpenSubscribeCompleteToast(false);
-        setIsToastClosing(false);
-      }, 4500); // 4.5초 후에 토스트 닫기
-
-      return () => {
-        clearTimeout(fadeOutTimer);
-        clearTimeout(closeTimer);
-      };
-    }
-  }, [isOpenSubscribeCompleteToast]);
-
-  useEffect(() => {
-    if (isOpenUnSubscribeCompleteToast) {
-      const fadeOutTimer = setTimeout(() => {
-        setIsToastClosing(true);
-      }, 3000); // 3초 후에 toast-fade-out 클래스 추가
-
-      const closeTimer = setTimeout(() => {
-        setIsOpenUnSubscribeCompleteToast(false);
-        setIsToastClosing(false);
-      }, 4500); // 4.5초 후에 토스트 닫기
-
-      return () => {
-        clearTimeout(fadeOutTimer);
-        clearTimeout(closeTimer);
-      };
-    }
-  }, [isOpenUnSubscribeCompleteToast]);
+  if (isPending) return <Loading />;
 
   return (
-    <div className='flex flex-col w-[37.5rem] mx-auto pt-6 pb-24'>
-      <div className='mt-2 flex items-center'>
+    <div className="flex flex-col w-[37.5rem] mx-auto pt-6 pb-24">
+      <div className="mt-2 flex items-center">
         <button
           onClick={() => {
             router.back();
           }}
         >
           <svg
-            xmlns='http://www.w3.org/2000/svg'
-            height='24'
-            viewBox='0 -960 960 960'
-            width='24'
+            xmlns="http://www.w3.org/2000/svg"
+            height="24"
+            viewBox="0 -960 960 960"
+            width="24"
           >
-            <path d='m112.769-480 308.616 308.615q8.846 8.846 8.731 21.154-.116 12.308-8.962 21.154T400-120.231q-12.308 0-21.154-8.846L73.154-434.538Q63.46-444.231 59-456.154 54.538-468.077 54.538-480T59-503.846q4.461-11.923 14.154-21.616l305.692-305.692q8.846-8.846 21.269-8.731 12.424.116 21.27 8.962t8.846 21.154q0 12.308-8.846 21.154L112.769-480Z' />
+            <path d="m112.769-480 308.616 308.615q8.846 8.846 8.731 21.154-.116 12.308-8.962 21.154T400-120.231q-12.308 0-21.154-8.846L73.154-434.538Q63.46-444.231 59-456.154 54.538-468.077 54.538-480T59-503.846q4.461-11.923 14.154-21.616l305.692-305.692q8.846-8.846 21.269-8.731 12.424.116 21.27 8.962t8.846 21.154q0 12.308-8.846 21.154L112.769-480Z" />
           </svg>
         </button>
-        <h1 className='mx-auto font-semibold text-lg text-[#333d4b]'>
+        <h1 className="mx-auto font-semibold text-lg text-[#333d4b]">
           구독한 태그
         </h1>
       </div>
 
-      <div className='mt-9'>
+      <div className="mt-9">
         <SubscribedTagList
-          resData={resData}
-          setResData={setResData}
-          setIsOpenSubscribeCompleteToast={setIsOpenSubscribeCompleteToast}
-          setIsOpenUnSubscribeCompleteToast={setIsOpenUnSubscribeCompleteToast}
+          mySubscribedTagInfos={mySubscribedTagInfos}
+          setMySubscribedTagInfos={setMySubscribedTagInfos}
           setIsOpenBottomDrawer={setIsOpenBottomDrawer}
           selectedTagInfo={selectedTagInfo}
           setSelectedTagInfo={setSelectedTagInfo}
         />
       </div>
 
-      {(isOpenSubscribeCompleteToast || isOpenUnSubscribeCompleteToast) && (
-        <Toast
-          className={`w-fit fixed bottom-14 left-14 bg-[#222222] py-3 pr-5 ${
-            isToastClosing ? 'toast-fade-out' : 'toast-fade-in'
-          }`}
-        >
-          <div className='inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-green-500 dark:bg-green-800 dark:text-green-200'>
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              height='27.5px'
-              viewBox='0 -960 960 960'
-              width='27.5px'
-              fill='#75d5ad'
-            >
-              <path d='m382-354 339-339q12-12 28-12t28 12q12 12 12 28.5T777-636L410-268q-12 12-28 12t-28-12L182-440q-12-12-11.5-28.5T183-497q12-12 28.5-12t28.5 12l142 143Z' />
-            </svg>
-          </div>
-          <div className='ml-1 text-[0.825rem] font-medium text-white'>
-            {isOpenSubscribeCompleteToast ? (
-              <>&quot;{selectedTagInfo.tag}&quot; 구독이 완료되었습니다</>
-            ) : (
-              <>&quot;{selectedTagInfo.tag}&quot; 구독이 취소되었습니다</>
-            )}
-          </div>
-        </Toast>
-      )}
-
       {(isOpenBottomDrawer || isBottomDrawerClosing) && (
         <div
           className={`z-10 fixed top-0 left-0 flex justify-center place-items-end w-screen h-full bg-[#111827] bg-opacity-50 ${
-            isBottomDrawerClosing ? 'fade-out' : 'fade-in'
+            isBottomDrawerClosing ? "fade-out" : "fade-in"
           } `}
         >
           <div
             ref={drawerRef}
             className={`w-[40rem] h-fit bg-white rounded-t-2xl p-4 pb-8 ${
               isBottomDrawerClosing
-                ? 'bottom-drawer-slide-down'
-                : 'bottom-drawer-slide-up'
+                ? "bottom-drawer-slide-down"
+                : "bottom-drawer-slide-up"
             }`}
           >
-            <div className='flex justify-end'>
+            <div className="flex justify-end">
               <button
                 onClick={() => {
                   closeDrawer();
                 }}
-                className='p-2'
+                className="p-2"
               >
                 <svg
-                  stroke='currentColor'
-                  fill='none'
-                  strokeWidth='2'
-                  viewBox='0 0 24 24'
-                  aria-hidden='true'
-                  className='w-6 h-6'
-                  height='1em'
-                  width='1em'
-                  xmlns='http://www.w3.org/2000/svg'
+                  stroke="currentColor"
+                  fill="none"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  className="w-6 h-6"
+                  height="1em"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    strokeLinecap='round'
-                    strokeLinejoin='round'
-                    d='M6 18L18 6M6 6l12 12'
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
                   ></path>
                 </svg>
               </button>
             </div>
 
-            <div className='flex flex-col gap-y-3'>
-              <div className='flex flex-col items-start gap-y-1 pb-4 border-b'>
+            <div className="flex flex-col gap-y-3">
+              <div className="flex flex-col items-start gap-y-1 pb-4 border-b">
                 <button
                   onClick={() => {
-                    setResData((prevData) =>
-                      prevData.map((item) =>
-                        item.tagId === selectedTagInfo.tagId
-                          ? {
-                              ...item,
-                              isReceiveNotification: true,
-                            }
-                          : item
-                      )
+                    enableReceiveNotificationMutation.mutate(
+                      selectedTagInfo.tagId
                     );
-                    setSelectedTagInfo((prev) => ({
-                      ...prev,
-                      isReceiveNotification: true,
-                    }));
-                    handleButtonInBottomDrawaberClick();
                   }}
-                  className='w-full py-2 flex items-center gap-x-2'
+                  className="w-full py-2 flex items-center gap-x-2"
                 >
                   <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    height='20'
-                    viewBox='0 -960 960 960'
-                    width='20'
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
                     fill={`${
                       selectedTagInfo.isReceiveNotification
-                        ? '#5f646b'
-                        : '#a0a5ac'
+                        ? "#5f646b"
+                        : "#a0a5ac"
                     }`}
                   >
-                    <path d='M200-200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-83 50-147.5T420-792v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 84.5T720-560v280h40q17 0 28.5 11.5T800-240q0 17-11.5 28.5T760-200H200ZM480-80q-33 0-56.5-23.5T400-160h160q0 33-23.5 56.5T480-80Z' />
+                    <path d="M200-200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-83 50-147.5T420-792v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 84.5T720-560v280h40q17 0 28.5 11.5T800-240q0 17-11.5 28.5T760-200H200ZM480-80q-33 0-56.5-23.5T400-160h160q0 33-23.5 56.5T480-80Z" />
                   </svg>
                   <span
                     className={`relative flex items-center text-[0.825rem] ${
                       selectedTagInfo.isReceiveNotification
-                        ? 'font-bold'
-                        : 'font-medium'
+                        ? "font-bold"
+                        : "font-medium"
                     }`}
                   >
                     새 글 알림 받기
                     {selectedTagInfo.isReceiveNotification && (
                       <svg
-                        xmlns='http://www.w3.org/2000/svg'
-                        height='24px'
-                        viewBox='0 -960 960 960'
-                        width='24px'
-                        fill='#3a8af9'
-                        className='absolute right-[-2rem]'
+                        xmlns="http://www.w3.org/2000/svg"
+                        height="24px"
+                        viewBox="0 -960 960 960"
+                        width="24px"
+                        fill="#3a8af9"
+                        className="absolute right-[-2rem]"
                       >
-                        <path d='m382-373.98 333.93-333.93q17.05-16.96 40.18-16.96t40.09 16.75q16.95 16.74 16.95 40.13 0 23.38-16.95 40.34L421.63-253.33q-16.77 16.96-39.54 16.96-22.76 0-39.72-16.96l-176.8-176.56q-16.96-16.93-16.58-40.12.38-23.19 17.13-40.14 16.98-17.2 40.25-17.2 23.26 0 40.22 17.2L382-373.98Z' />
+                        <path d="m382-373.98 333.93-333.93q17.05-16.96 40.18-16.96t40.09 16.75q16.95 16.74 16.95 40.13 0 23.38-16.95 40.34L421.63-253.33q-16.77 16.96-39.54 16.96-22.76 0-39.72-16.96l-176.8-176.56q-16.96-16.93-16.58-40.12.38-23.19 17.13-40.14 16.98-17.2 40.25-17.2 23.26 0 40.22 17.2L382-373.98Z" />
                       </svg>
                     )}
                   </span>
@@ -280,55 +399,43 @@ export default function MySubscribedTags() {
 
                 <button
                   onClick={() => {
-                    setResData((prevData) =>
-                      prevData.map((item) =>
-                        item.tagId === selectedTagInfo.tagId
-                          ? {
-                              ...item,
-                              isReceiveNotification: false,
-                            }
-                          : item
-                      )
+                    disableReceiveNotificationMutation.mutate(
+                      selectedTagInfo.tagId
                     );
-                    setSelectedTagInfo((prev) => ({
-                      ...prev,
-                      isReceiveNotification: false,
-                    }));
-                    handleButtonInBottomDrawaberClick();
                   }}
-                  className='w-full py-2 flex items-center gap-x-2'
+                  className="w-full py-2 flex items-center gap-x-2"
                 >
                   <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    height='20'
-                    viewBox='0 -960 960 960'
-                    width='20'
+                    xmlns="http://www.w3.org/2000/svg"
+                    height="20"
+                    viewBox="0 -960 960 960"
+                    width="20"
                     fill={`${
                       !selectedTagInfo.isReceiveNotification
-                        ? '#5f646b'
-                        : '#a0a5ac'
+                        ? "#5f646b"
+                        : "#a0a5ac"
                     }`}
                   >
-                    <path d='M646-200H200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-33 8.5-65t25.5-61l126 126H288L84-764q-11-11-11-28t11-28q11-11 28-11t28 11l680 680q11 11 11.5 27.5T820-84q-11 11-28 11t-28-11L646-200Zm74-251q0 12-7 22t-18 15q-11 5-23 2.5T652-422L367-707q-7-7-10-15t-3-17q0-11 5.5-21.5T375-776q11-5 22-9t23-7v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 85t50 147v109ZM480-80q-30 0-53.5-16.5T403-141q0-8 6.5-13.5T424-160h112q8 0 14.5 5.5T557-141q0 28-23.5 44.5T480-80Z' />
+                    <path d="M646-200H200q-17 0-28.5-11.5T160-240q0-17 11.5-28.5T200-280h40v-280q0-33 8.5-65t25.5-61l126 126H288L84-764q-11-11-11-28t11-28q11-11 28-11t28 11l680 680q11 11 11.5 27.5T820-84q-11 11-28 11t-28-11L646-200Zm74-251q0 12-7 22t-18 15q-11 5-23 2.5T652-422L367-707q-7-7-10-15t-3-17q0-11 5.5-21.5T375-776q11-5 22-9t23-7v-28q0-25 17.5-42.5T480-880q25 0 42.5 17.5T540-820v28q80 20 130 85t50 147v109ZM480-80q-30 0-53.5-16.5T403-141q0-8 6.5-13.5T424-160h112q8 0 14.5 5.5T557-141q0 28-23.5 44.5T480-80Z" />
                   </svg>
                   <span
                     className={`relative flex items-center text-[0.825rem] ${
                       !selectedTagInfo.isReceiveNotification
-                        ? 'font-bold'
-                        : 'font-medium'
+                        ? "font-bold"
+                        : "font-medium"
                     }`}
                   >
                     새 글 알림 끄기
                     {!selectedTagInfo.isReceiveNotification && (
                       <svg
-                        xmlns='http://www.w3.org/2000/svg'
-                        height='24px'
-                        viewBox='0 -960 960 960'
-                        width='24px'
-                        fill='#3a8af9'
-                        className='absolute right-[-2rem]'
+                        xmlns="http://www.w3.org/2000/svg"
+                        height="24px"
+                        viewBox="0 -960 960 960"
+                        width="24px"
+                        fill="#3a8af9"
+                        className="absolute right-[-2rem]"
                       >
-                        <path d='m382-373.98 333.93-333.93q17.05-16.96 40.18-16.96t40.09 16.75q16.95 16.74 16.95 40.13 0 23.38-16.95 40.34L421.63-253.33q-16.77 16.96-39.54 16.96-22.76 0-39.72-16.96l-176.8-176.56q-16.96-16.93-16.58-40.12.38-23.19 17.13-40.14 16.98-17.2 40.25-17.2 23.26 0 40.22 17.2L382-373.98Z' />
+                        <path d="m382-373.98 333.93-333.93q17.05-16.96 40.18-16.96t40.09 16.75q16.95 16.74 16.95 40.13 0 23.38-16.95 40.34L421.63-253.33q-16.77 16.96-39.54 16.96-22.76 0-39.72-16.96l-176.8-176.56q-16.96-16.93-16.58-40.12.38-23.19 17.13-40.14 16.98-17.2 40.25-17.2 23.26 0 40.22 17.2L382-373.98Z" />
                       </svg>
                     )}
                   </span>
@@ -338,29 +445,11 @@ export default function MySubscribedTags() {
               <div>
                 <button
                   onClick={(e) => {
-                    setIsOpenSubscribeCompleteToast(false);
-                    setIsOpenUnSubscribeCompleteToast(false);
-
-                    setTimeout(() => {
-                      setIsOpenUnSubscribeCompleteToast(true);
-                    }, 50);
-
-                    setResData((prevData) =>
-                      prevData.map((item) =>
-                        item.tagId === selectedTagInfo.tagId
-                          ? {
-                              ...item,
-                              isSubscribed: false,
-                            }
-                          : item
-                      )
-                    );
-
-                    closeDrawer();
+                    unsubscribeTagMutation.mutate(selectedTagInfo.tagId);
                   }}
-                  className='w-full flex items-center gap-x-2 py-2'
+                  className="w-full flex items-center gap-x-2 py-2"
                 >
-                  <span className='text-[0.825rem] font-medium'>구독 취소</span>
+                  <span className="text-[0.825rem] font-medium">구독 취소</span>
                 </button>
               </div>
             </div>

--- a/apps/client/app/my-page/community-history/page.tsx
+++ b/apps/client/app/my-page/community-history/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import { formatDate } from "@/utils/formatDate";
 import Loading from "@/app/loading";
 
-// 회원의 구독한 태그 목록 정보 조회 API
+// 내가 쓴 커뮤니티 게시글 목록 조회 API
 const fetchMyCommunityPostInfos = () => {
   return axiosInstance.get(`/private/community/posts/my`);
 };


### PR DESCRIPTION
resolve #49 

## Description

로그인 한 회원이 구독한 태그 페이지에 접근했을 때 해당 페이지 내에서
이용 가능한 기능들에 대하여 관련 APIs를 일괄적으로 연동시킬 수 있도록
하였습니다.

> [!note]
> - `회원의 구독한 태그 목록 정보 조회` API 연동
> - `태그 구독하기` API 연동
> - `태그 구독 취소하기` API 연동
> - `태그 새 글 알림 활성화` API 연동
> - `태그 새 글 알림 비활성화` 연동

- 페이지 내 APIs 연동 후 기능 사용 화면

https://github.com/user-attachments/assets/8b66b969-fab2-4698-8b04-f2d9ebce2181