### PR TITLE
feat: Prettier 설정 파일 추가 및 Image 컴포넌트 이미지 비율 유지 속성 추가

### DIFF
--- a/apps/client/.prettierrc
+++ b/apps/client/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "jsxSingleQuote": true
+}

--- a/apps/client/app/community/components/entirePost/PostListItem.tsx
+++ b/apps/client/app/community/components/entirePost/PostListItem.tsx
@@ -50,7 +50,7 @@ export default function PostListItem(props: TagPostListItemProps) {
               alt='main_1Image'
               fill
               quality={100}
-              className='rounded-[0.275rem]'
+              className='rounded-[0.275rem] object-cover'
             />
             <div
               className='absolute right-[0.175rem] bottom-[0.175rem] w-6 h-5 flex justify-center items-center rounded-xl'

--- a/apps/client/app/community/components/hotPost/HotPostListItem.tsx
+++ b/apps/client/app/community/components/hotPost/HotPostListItem.tsx
@@ -31,9 +31,8 @@ export default function HotPostListItem(props: HotPostListItemProps) {
               src={testImg}
               alt='main_1Image'
               fill
-              // 이미지 비율 유지하며 부모 요소에 맞춤
               quality={100}
-              className='rounded-md'
+              className='rounded-md object-cover'
             />
             <div
               className='absolute right-[0.175rem] bottom-[0.175rem] w-6 h-5 flex justify-center items-center rounded-xl'

--- a/apps/client/app/community/components/swiperBannerContents/Slide1.tsx
+++ b/apps/client/app/community/components/swiperBannerContents/Slide1.tsx
@@ -20,7 +20,7 @@ export const Slide1: FC<Slide1Props> = ({ handlePrev, handleNext }) => {
         fill
         // 이미지 비율 유지하며 부모 요소에 맞춤
         quality={100}
-        className='rounded-md'
+        className='rounded-md object-cover'
       />
     </a>
   );

--- a/apps/client/app/community/components/swiperBannerContents/Slide2.tsx
+++ b/apps/client/app/community/components/swiperBannerContents/Slide2.tsx
@@ -20,7 +20,7 @@ export const Slide2: FC<Slide2Props> = ({ handlePrev, handleNext }) => {
         fill
         // 이미지 비율 유지하며 부모 요소에 맞춤
         quality={100}
-        className='rounded-md'
+        className='rounded-md object-cover'
       />
     </a>
   );

--- a/apps/client/app/community/components/tagPost/TagPostListItem.tsx
+++ b/apps/client/app/community/components/tagPost/TagPostListItem.tsx
@@ -50,7 +50,7 @@ export default function TagPostListItem(props: TagPostListItemProps) {
               alt='main_1Image'
               fill
               quality={100}
-              className='rounded-[0.275rem]'
+              className='rounded-[0.275rem] object-cover'
             />
             <div
               className='absolute right-[0.175rem] bottom-[0.175rem] w-6 h-5 flex justify-center items-center rounded-xl'

--- a/apps/client/app/community/feed/components/feedPost/FeedPostListItem.tsx
+++ b/apps/client/app/community/feed/components/feedPost/FeedPostListItem.tsx
@@ -56,7 +56,7 @@ export default function FeedPostListItem(props: FeedPostListItemProps) {
                   alt='main_1Image'
                   fill
                   quality={100}
-                  className='rounded-md'
+                  className='rounded-md object-cover'
                 />
                 <div
                   className='absolute right-2 bottom-2 w-6 h-5 flex justify-center items-center rounded-xl'

--- a/apps/client/app/community/page.tsx
+++ b/apps/client/app/community/page.tsx
@@ -32,7 +32,7 @@ export default function Community() {
             width={45}
             height={45}
             quality={100}
-            className='rounded-md'
+            className='rounded-md object-cover'
           />
           <span className='ml-2 lift-up text-[#333d4b] font-bold'>
             커뮤니티

--- a/apps/client/app/community/search/components/hotPost/HotPostListItem.tsx
+++ b/apps/client/app/community/search/components/hotPost/HotPostListItem.tsx
@@ -130,7 +130,7 @@ export default function HotPostListItem(props: HotPostListItemProps) {
               fill
               // 이미지 비율 유지하며 부모 요소에 맞춤
               quality={100}
-              className='rounded-md'
+              className='rounded-md object-cover'
             />
             <div
               className='absolute right-[0.175rem] bottom-[0.175rem] w-6 h-5 flex justify-center items-center rounded-xl'

--- a/apps/client/app/community/search/components/relatedSearchPost/RelatedSearchPostListItem.tsx
+++ b/apps/client/app/community/search/components/relatedSearchPost/RelatedSearchPostListItem.tsx
@@ -128,7 +128,7 @@ export default function RelatedSearchPostListItem(
               fill
               // 이미지 비율 유지하며 부모 요소에 맞춤
               quality={100}
-              className='rounded-md'
+              className='rounded-md object-cover'
             />
             <div
               className='absolute right-[0.175rem] bottom-[0.175rem] w-6 h-5 flex justify-center items-center rounded-xl'

--- a/apps/client/app/community/search/components/swiperBannerContents/Slide1.tsx
+++ b/apps/client/app/community/search/components/swiperBannerContents/Slide1.tsx
@@ -20,7 +20,7 @@ export const Slide1: FC<Slide1Props> = ({ handlePrev, handleNext }) => {
         fill
         // 이미지 비율 유지하며 부모 요소에 맞춤
         quality={100}
-        className='rounded-md'
+        className='rounded-md object-cover'
       />
     </a>
   );

--- a/apps/client/app/community/search/components/swiperBannerContents/Slide2.tsx
+++ b/apps/client/app/community/search/components/swiperBannerContents/Slide2.tsx
@@ -20,7 +20,7 @@ export const Slide2: FC<Slide2Props> = ({ handlePrev, handleNext }) => {
         fill
         // 이미지 비율 유지하며 부모 요소에 맞춤
         quality={100}
-        className='rounded-md'
+        className='rounded-md object-cover'
       />
     </a>
   );


### PR DESCRIPTION
resolve #51 

## Description

현재 `vscode` 내에서 코드 작업 시에 클라이언트 측 모든 작업 인원이 통일된 Prettier 규칙을 프로젝트 내에서 사용할 수 있도록 `.prettierrc` 파일을 추가하였고, 커뮤니티 관련 페이지 구성 컴포넌트 중에서 `Image` 컴포넌트를 사용 중이던 컴포넌트들에서 이미지 비율이 올바르지 유지되지 않는 요소가 확인되어 해당 요소들의 이미지 비율이 올바르게 되도록 관련 TailwindCSS 코드를 일괄적으로 추가하였습니다.