### PR TITLE
fix: 파일 업로드 API 엔드포인트 정정

### DIFF
--- a/apps/server/src/main/java/com/example/controller/community/UploadController.java
+++ b/apps/server/src/main/java/com/example/controller/community/UploadController.java
@@ -16,7 +16,6 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/private/upload")
 public class UploadController {
   private final UploadService uploadService;
 


### PR DESCRIPTION
resolve #53 

## Description

현재 `파일 업로드` API 엔드포인트가 `/private/upload/private/community/upload`으로
`RequestMapping` 애너테이션에 의해 `/private/upload`가 포함되어 있는데, 이를 제거하여
`/private/community/upload`가 되도록 하였습니다.