### PR TITLE
fix: 태그 목록 조회API 응답 바디 필드명 변경 #55

### DIFF
--- a/apps/server/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
+++ b/apps/server/src/main/java/com/example/dto/response/PostsByTagInfoResponse.java
@@ -42,7 +42,7 @@ public class PostsByTagInfoResponse {
     @Builder
     public static class TagsDto {
         private Long tagId;
-        private String tag;
+        private String tagName;
     }
 
     @Getter

--- a/apps/server/src/main/java/com/example/dto/response/SearchTagsResponse.java
+++ b/apps/server/src/main/java/com/example/dto/response/SearchTagsResponse.java
@@ -13,7 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class SearchTagsResponse {
     private Long tagId;
-    private String tag;
+    private String tagName;
     private Long postsCount;
     private List<TagInfoResponse> relatedTags; // 연관 태그
     private List<PostsByTagInfoResponse> posts; // 검색된 게시글들

--- a/apps/server/src/main/java/com/example/dto/response/TagSubInfoResponse.java
+++ b/apps/server/src/main/java/com/example/dto/response/TagSubInfoResponse.java
@@ -9,7 +9,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class TagSubInfoResponse {
     private Long tagId;
-    private String tag;
+    private String tagName;
     private Boolean isReceiveNotification;
     private Long postCount;
 }

--- a/apps/server/src/main/java/com/example/service/community/CommunityService.java
+++ b/apps/server/src/main/java/com/example/service/community/CommunityService.java
@@ -372,7 +372,7 @@ public class CommunityService {
 
       return ApiResult.success(SearchTagsResponse.builder()
         .tagId(null)
-        .tag(null)
+        .tagName(null)
         .postsCount(null)
         .relatedTags(relatedTags)
         .posts(posts)
@@ -386,7 +386,7 @@ public class CommunityService {
 
     return ApiResult.success(SearchTagsResponse.builder()
       .tagId(tag.getId())
-      .tag(tag.getTagName())
+      .tagName(tag.getTagName())
       .postsCount(postsCount)
       .relatedTags(relatedTags)
       .posts(posts)
@@ -505,7 +505,7 @@ public class CommunityService {
           .tags(postTags.stream()
             .map(tag -> PostsByTagInfoResponse.TagsDto.builder()
               .tagId(tag.getTag().getId())
-              .tag(tag.getTag().getTagName())
+              .tagName(tag.getTag().getTagName())
               .build())
             .collect(Collectors.toList()))
           .views(post.getViews())

--- a/apps/server/src/main/java/com/example/service/subscribe/SubscribeService.java
+++ b/apps/server/src/main/java/com/example/service/subscribe/SubscribeService.java
@@ -98,7 +98,7 @@ public class SubscribeService {
         List<TagSubInfoResponse> tagResponses = subscribedTags.stream()
                 .map(tagSub -> TagSubInfoResponse.builder()
                         .tagId(tagSub.getTag().getId())
-                        .tag(tagSub.getTag().getTagName())
+                        .tagName(tagSub.getTag().getTagName())
                         .isReceiveNotification(tagSub.getSubNotify())
                         .postCount(postRepository.countPostsByTagId(tagSub.getTag().getId()))
                         .build())


### PR DESCRIPTION
resolve #55

## Description

`tag -> tagName`

**Subscribe**
- 회원의 구독 태그 목록 조회

**Community**
 - 태그 관련 통합 검색 정보 조회 
 - 내가 쓴 커뮤니티 게시글 목록 정보 조회
 - 태그 기반 커뮤니티 게시글 목록 정보 조회
 - 게시글 검색 정보 조회   
 - 최신 커뮤니티 게시글 목록 조회
 - 인기 커뮤니티 게시글 목록 조회

