### PR TITLE
feat: 일한 입력 값에 대한 useDebounce custom hook refetching 기능 추가

### DIFF
--- a/apps/client/utils/hooks/useDebounce.ts
+++ b/apps/client/utils/hooks/useDebounce.ts
@@ -4,16 +4,21 @@ function useDebounce(value: string, delay: number): string {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
   useEffect(() => {
-    // 지연 시간 후에 value 업데이트
     const handler = setTimeout(() => {
       setDebouncedValue(value);
     }, delay);
 
-    // Cleanup 함수에서 timer를 clear
     return () => {
       clearTimeout(handler);
     };
-  }, [value, delay]); // value 또는 delay가 변경될 때마다 effect 실행
+  }, [value, delay]);
+
+  // 상태가 빈 문자열일 경우에도 항상 새로운 값으로 취급되도록 강제 재설정
+  useEffect(() => {
+    if (value === '') {
+      setDebouncedValue('');
+    }
+  }, [value]);
 
   return debouncedValue;
 }


### PR DESCRIPTION
resolve #70 

## Description

현재 프로젝트에서 사용 중인 `useDebounce` 커스텀 훅의 경우 동일한 입력 값에 대해 딜레이 타임이 경과하기
이전에 지난 입력 값으로 사용 중이던 값을 다시 입력 값으로 사용할 경우에 fetching이 일어나지 않도록 되어 있어,
게시글 등록/수정 페이지 내에서 태그 등록 시 연관 검색 태그 창이 다시 표시되지 않는 문제가 있어서 이를 refetching이
되도록 수정하고자 하였습니다.