### PR TITLE
feat: post 도메인 내 content 칼럼 데이터형 text로 변경

### DIFF
--- a/apps/server/src/main/java/com/example/domain/community/Post.java
+++ b/apps/server/src/main/java/com/example/domain/community/Post.java
@@ -26,6 +26,7 @@ public class Post {
 
     private String title;
 
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "created_time")


### PR DESCRIPTION
resolve #-

## Description

post 테이블 내에 `content` 칼럼의 경우 현재까지 기본값에 따라 `varchar` 타입으로 설정되어
있었지만, 해당 칼럼은 실제 커뮤니티 게시글 내에서 글의 본문이 저장되는 칼럼이므로, 글자수의 제한이
크지 않도록 `text` 타입으로 변경하였습니다.