### PR TITLE
feat: 커뮤니티 피드 페이지 내 구독하기 기능 추가

### DIFF
--- a/apps/client/app/community/feed/page.tsx
+++ b/apps/client/app/community/feed/page.tsx
@@ -17,8 +17,8 @@ const fetchMySubscribedTagInfos = () => {
 };
 
 // 태그 구독하기 API
-const subscribeTag = (tagId: number) => {
-  return axiosInstance.post(`/private/subscribe/tags/${tagId}`);
+const subscribeTag = (tagName: string) => {
+  return axiosInstance.post(`/private/subscribe?tag=${tagName}`);
 };
 
 // 태그 구독 취소하기 API
@@ -426,7 +426,7 @@ export default function Feed() {
               ) : (
                 <button
                   onClick={() => {
-                    subscribeTagMutation.mutate(subscribedTagInfo.tagId);
+                    subscribeTagMutation.mutate(tagQuery);
                   }}
                   className='relative w-24 flex justify-center items-center gap-x-[0.175rem] px-7 py-2 rounded-full bg-[#3a8af9] border border-[#3a8af9]'
                 >


### PR DESCRIPTION
resolve #74 

## Description

특정 태그에 대하여 피드 페이지에 접근했을 경우 페이지 상단에 해당 태그에 대한
구독하기 버튼이 표시되는데, 회원 유저의 경우 버튼 클릭 시 실제 구독이 되도록
관련 서버 API를 연동하였습니다.