### PR TITLE
feat: 비속어 패널티 부여에 따른 modal 창 표시 로직 수정

### DIFF
--- a/apps/client/app/community/post/[postId]/page.tsx
+++ b/apps/client/app/community/post/[postId]/page.tsx
@@ -143,20 +143,18 @@ export default function CommunityPost(props: DefaultProps) {
     },
     onSuccess: (data) => {
       const httpStatusCode = data.status;
+      const isPenalized = data.data.response.isPenalized;
 
       switch (httpStatusCode) {
         case 200:
-          if (data.data === '비속어 사용 내역이 기록되었습니다.') {
-            setOpenDetectedBadWordGuideModal('default');
-            break;
-          }
-
-          if (
-            data.data ===
-            '비속어 사용 내역이 기록되었으며, 패널티가 부여되었습니다.'
-          ) {
+          if (isPenalized) {
             setOpenRestrictGuideModal('default');
           }
+
+          if (!isPenalized) {
+            setOpenDetectedBadWordGuideModal('default');
+          }
+
           // 쿼리 데이터 업데이트
           queryClient.invalidateQueries({
             queryKey: ['communityPostInfo'],
@@ -977,11 +975,7 @@ export default function CommunityPost(props: DefaultProps) {
                   </span>
                   <button
                     disabled={true}
-                    className={`w-[3.75rem] py-[0.4rem] font-medium ${
-                      comment
-                        ? 'bg-[#3a8af9] hover:bg-[#1c6cdb]'
-                        : 'bg-[#90c2ff]'
-                    } text-xs text-white rounded-[0.3rem]`}
+                    className={`w-[3.75rem] py-[0.4rem] font-medium bg-[#90c2ff] text-xs text-white rounded-[0.3rem]`}
                   >
                     등록
                   </button>


### PR DESCRIPTION
resolve #92 

## Description

커뮤니티 게시글 내에서 로그인 한 유저가 댓글 혹은 답글로 비속어를 포함하여 API 요청을 하는 경우
페이지 내에서 경고 및 제재에 대한 modal창을 표시하여 사용자의 커뮤니티 활동 중 유의사항을
정확히 인지할 수 있도록 관련 로직이 표시되는 코드를 추가했습니다.